### PR TITLE
Update to v5.x of terraform-provider-aws

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
Switch this and dependent modules to the v5.x of the Terraform AWS provider to support the latest AWS features, like RDS' io2.